### PR TITLE
Fix array response types

### DIFF
--- a/ReactiveAPI/JSONReactiveAPI.swift
+++ b/ReactiveAPI/JSONReactiveAPI.swift
@@ -164,40 +164,4 @@ public extension JSONReactiveAPI {
             return Single.error(error)
         }
     }
-
-    // body params as dictionary and array response type
-    func request<D: Decodable>(_ method: ReactiveAPIHTTPMethod = .get,
-                               url: URL,
-                               headers: [String: Any?]? = nil,
-                               queryParams: [String: Any?]? = nil,
-                               bodyParams: [String: Any?]? = nil) -> Single<[D]> {
-        do {
-            let request = try URLRequest.createForJSON(with: url,
-                                                       method: method,
-                                                       headers: headers,
-                                                       queryParams: queryParams,
-                                                       bodyParams: bodyParams)
-            return rxDataRequestArray(request)
-        } catch {
-            return Single.error(error)
-        }
-    }
-
-    // body params as encodable and array response type
-    func request<E: Encodable, D: Decodable>(_ method: ReactiveAPIHTTPMethod = .get,
-                                             url: URL,
-                                             headers: [String: Any?]? = nil,
-                                             queryParams: [String: Any?]? = nil,
-                                             body: E? = nil) -> Single<[D]> {
-        do {
-            let request = try URLRequest.createForJSON(with: url,
-                                                       method: method,
-                                                       headers: headers,
-                                                       queryParams: queryParams,
-                                                       body: body)
-            return rxDataRequestArray(request)
-        } catch {
-            return Single.error(error)
-        }
-    }
 }

--- a/ReactiveAPI/JSONReactiveAPI.swift
+++ b/ReactiveAPI/JSONReactiveAPI.swift
@@ -70,22 +70,6 @@ open class JSONReactiveAPI: ReactiveAPI {
             }
         }
     }
-
-    private func rxDataRequestArray<D: Decodable>(_ request: URLRequest) -> Single<[D]> {
-        return rxDataRequest(request).flatMap { data in
-            do {
-                let decoded = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions())
-
-                if let decodedArray = decoded as? [D] {
-                    return Single.just(decodedArray)
-                } else {
-                    return Single.error(ReactiveAPIError.jsonDeserializationError("unable to deserialize to JSON Array", data))
-                }
-            } catch {
-                return Single.error(error)
-            }
-        }
-    }
     
     private func rxDataRequestDiscardingPayload(_ request: URLRequest) -> Single<Void> {
         return rxDataRequest(request).map { _ in () }


### PR DESCRIPTION
When declaring an API with the following signature 

```swift
func myAPI() -> Single<[MyDataType]>
```
 Xcode won't compile complaining about "ambiguous reference". This is because:

```swift
    func request<D: Decodable>(_ method: ReactiveAPIHTTPMethod = .get,
                               url: URL,
                               headers: [String: Any?]? = nil,
                               queryParams: [String: Any?]? = nil,
                               bodyParams: [String: Any?]? = nil) -> Single<[D]>
```
conflicts with
```swift
    func request<D: Decodable>(_ method: ReactiveAPIHTTPMethod = .get,
                               url: URL,
                               headers: [String: Any?]? = nil,
                               queryParams: [String: Any?]? = nil,
                               bodyParams: [String: Any?]? = nil) -> Single<D>
```
because` [D]` is the same as `D` when `D: Decodable`

Fixed by removing the redundant functions!