### PR TITLE
Query string type converter

### DIFF
--- a/ReactiveAPI/Extensions/URLRequest+ReactiveAPI.swift
+++ b/ReactiveAPI/Extensions/URLRequest+ReactiveAPI.swift
@@ -12,13 +12,14 @@ extension URLRequest {
                                      method: ReactiveAPIHTTPMethod = .get,
                                      headers: [String: Any?]? = nil,
                                      queryParams: [String: Any?]? = nil,
-                                     bodyParams: [String: Any?]? = nil) throws -> URLRequest {
+                                     bodyParams: [String: Any?]? = nil,
+                                     queryStringTypeConverter: ReactiveAPITypeConverter?) throws -> URLRequest {
         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
             else { throw ReactiveAPIError.URLComponentsError(url) }
 
         if let queryParams = queryParams {
                 urlComponents.queryItems = (urlComponents.queryItems ?? [URLQueryItem]()) + queryParams
-                    .compactMapValues({ $0 })
+                    .compactMapValues({ queryStringTypeConverter?($0) ?? $0 })
                     .compactMap({ URLQueryItem(name: $0, value: "\($1)") })
         }
 
@@ -43,11 +44,13 @@ extension URLRequest {
                                      method: ReactiveAPIHTTPMethod = .get,
                                      headers: [String: Any?]? = nil,
                                      queryParams: [String: Any?]? = nil,
-                                     body: Encodable? = nil) throws -> URLRequest {
+                                     body: Encodable? = nil,
+                                     queryStringTypeConverter: ReactiveAPITypeConverter?) throws -> URLRequest {
         return try createForJSON(with: url,
                                  method: method,
                                  headers: headers,
                                  queryParams: queryParams,
-                                 bodyParams: body?.dictionary)
+                                 bodyParams: body?.dictionary,
+                                 queryStringTypeConverter: queryStringTypeConverter)
     }
 }

--- a/ReactiveAPI/Info.plist
+++ b/ReactiveAPI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.6</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ReactiveAPI/JSONReactiveAPI.swift
+++ b/ReactiveAPI/JSONReactiveAPI.swift
@@ -9,6 +9,7 @@ open class JSONReactiveAPI: ReactiveAPI {
     public var authenticator: ReactiveAPIAuthenticator? = nil
     public var requestInterceptors: [ReactiveAPIRequestInterceptor] = []
     public var cache: ReactiveAPICache? = nil
+    public var queryStringTypeConverter: ReactiveAPITypeConverter?
     
     required public init(session: Reactive<URLSession>, decoder: ReactiveAPIDecoder, baseUrl: URL) {
         self.session = session
@@ -92,7 +93,8 @@ public extension JSONReactiveAPI {
                                                        method: method,
                                                        headers: headers,
                                                        queryParams: queryParams,
-                                                       bodyParams: bodyParams)
+                                                       bodyParams: bodyParams,
+                                                       queryStringTypeConverter: queryStringTypeConverter)
             return rxDataRequest(request)
         } catch {
             return Single.error(error)
@@ -110,7 +112,8 @@ public extension JSONReactiveAPI {
                                                        method: method,
                                                        headers: headers,
                                                        queryParams: queryParams,
-                                                       body: body)
+                                                       body: body,
+                                                       queryStringTypeConverter: queryStringTypeConverter)
             return rxDataRequest(request)
         } catch {
             return Single.error(error)
@@ -128,7 +131,8 @@ public extension JSONReactiveAPI {
                                                        method: method,
                                                        headers: headers,
                                                        queryParams: queryParams,
-                                                       bodyParams: bodyParams)
+                                                       bodyParams: bodyParams,
+                                                       queryStringTypeConverter: queryStringTypeConverter)
             return rxDataRequestDiscardingPayload(request)
         } catch {
             return Single.error(error)
@@ -146,7 +150,8 @@ public extension JSONReactiveAPI {
                                                        method: method,
                                                        headers: headers,
                                                        queryParams: queryParams,
-                                                       body: body)
+                                                       body: body,
+                                                       queryStringTypeConverter: queryStringTypeConverter)
             return rxDataRequestDiscardingPayload(request)
         } catch {
             return Single.error(error)

--- a/ReactiveAPI/ReactiveAPI.swift
+++ b/ReactiveAPI/ReactiveAPI.swift
@@ -1,9 +1,12 @@
 import Foundation
 import RxSwift
 
+public typealias ReactiveAPITypeConverter = (_ value: Any?) -> String?
+
 public protocol ReactiveAPI {
     var authenticator: ReactiveAPIAuthenticator? { get set }
     var requestInterceptors: [ReactiveAPIRequestInterceptor] { get set }
+    var queryStringTypeConverter: ReactiveAPITypeConverter? { get set }
     var cache: ReactiveAPICache? { get set }
     init(session: Reactive<URLSession>, decoder: ReactiveAPIDecoder, baseUrl: URL)
     func absoluteURL(_ endpoint: String) -> URL


### PR DESCRIPTION
It often happens to pass complex data types as query string (e.g. Date) and to have the need of doing custom string representation of the objects. This adds that possibility.